### PR TITLE
update readme & fix gwproxy allowed domains & edit ICAP url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Preparation
 
-This project doesn't apply url rewriting
+This project doesn't apply URL rewriting
 We needed to check the website requests to check domains of interest, (domains that should be proxied), which typically are:
 
 - Website main domain and www subdomain (if applicable)
@@ -35,15 +35,13 @@ We needed to check the website requests to check domains of interest, (domains t
 
 ### Configuration
 
-Use [this configuration file](https://github.com/k8-proxy/k8-reverse-proxy/blob/master/stable-src/gwproxy.env) as example
+Tweak **gwproxy.env** according to our configuration (a pre-configured file already included in the repository), This is a variables definition example: 
 
-- `ROOT_DOMAIN`: Domain used by the proxy (example: www.gov.uk.glasswall-icap.com is proxying www.gov.uk) 
-
-- `ALLOWED_DOMAINS` : Comma separated domains accepted by the proxy, typically this should be domains of interest with the `ROOT_DOMAIN` value appended
-
+- `ROOT_DOMAIN`: the domain appended to the original website domain, typically: glasswall-icap.com
+- `ALLOWED_DOMAINS` : Comma separated domains accepted by the proxy, typically this should be domains of interest (figured out in the previous step) with the `ROOT_DOMAIN` value appended
+- `ICAP_URL` : the URL of the ICAP server either running on a docker on the same machine or through a load-balancer server.
 - `SQUID_IP` IP address of squid proxy, used by nginx, should be only changed on advanced usage of the docker image (example: Kubernetes)
-
-- `SUBFILTER_ENV`: Space separated text substitution rules in response body, foramtted as **match,replace** , used for url rewriting as in **.gov.uk,.gov.uk.glasswall-icap.com**
+- `SUBFILTER_ENV`: Space separated text substitution rules in response body, formatted as **match,replace** , used for URL rewriting as in **.gov.uk,.gov.uk.glasswall-icap.com** , but since this project doesn't apply URL rewriting it will be an empty string. 
 
 ## Installation
 
@@ -69,7 +67,7 @@ Use [this configuration file](https://github.com/k8-proxy/k8-reverse-proxy/blob/
     cd k8-reverse-proxy/stable-src/
   ```
 
-- Tweak `openssl.cnf` to include domains of interest in **alt_names** section
+- Tweak `openssl.cnf` to include domains of interest in **alt_names** section (by default, this file is pre-configured in the repository).
 
 - Generate new SSL credentials
   
@@ -84,20 +82,44 @@ Use [this configuration file](https://github.com/k8-proxy/k8-reverse-proxy/blob/
     docker-compose up -d --build
   ```
   
-  You will need to use this command after every change to any of the configuration files **gwproxy.env**, **docker-compose.yaml**, if any.
+  From now on, you will need to use this command after every change to any of the configuration files **gwproxy.env**, ***subfilter.sh***, **docker-compose.yaml**, if any.
+  
+  ## Troubleshooting
+
+  Check if docker service is active   
+  
+  ```bash
+    systemctl status docker
+  ```
+  
+  Check if containers are up and running (not Restarting...)
+  
+  ```bash
+  docker-compose ps
+  ```
+  
+  If squid or nginx is not started correctly, then configuration parameters in `gwproxy.env` has been modified, execute:
+  
+  ```bash
+  docker-compose up -d --force-recreate
+  ```
+  
+  
   
   ## Client configuration
-
+  
 - Add hosts records to your client system hosts file ( i.e **Windows**: C:\Windows\System32\drivers\etc\hosts , **Linux, macOS and  Unix-like:** /etc/hosts ) as follows
   
   ```
   127.0.0.1 saaspoc1.sharepoint.com saaspoc1-my.sharepoint.com ukc-word-edit.officeapps.live.com ukc-excel.officeapps.live.com  ukc-powerpoint.officeapps.live.com 
   ```
   
-  In case the machine running the project is not your local computer, replace **127.0.0.1** with the project host IP.
+  In case you are using a client other than machine running the project , replace **127.0.0.1** with the project host machine IP,
   
   make sure that tcp ports **80** and **443** are reachable and not blocked by firewall.
   
+  * Move ***k8-reverse-proxy/stable-src/ca.pem*** to your client machine and add it to your browser/system ssl trust store.
+  
   ## Access the proxied site
   
-  You can access the proxied site by browsing [saaspoc1.sharepoint.com](https://saaspoc1.sharepoint.com) after adding `k8-reverse-proxy/stable-src/ca.pem` to your browser/system ssl trust store.
+  You can access the proxied site by browsing [saaspoc1.sharepoint.com](https://saaspoc1.sharepoint.com) .

--- a/gwproxy.env
+++ b/gwproxy.env
@@ -1,7 +1,7 @@
 # Allowed domains, comma separated
-ALLOWED_DOMAINS=saaspoc1.sharepoint.com,saaspoc1-my.sharepoint.com ukc-word-edit.officeapps.live.com ukc-excel.officeapps.live.com  ukc-powerpoint.officeapps.live.com 
+ALLOWED_DOMAINS=saaspoc1.sharepoint.com,saaspoc1-my.sharepoint.com,ukc-word-edit.officeapps.live.com,ukc-excel.officeapps.live.com,ukc-powerpoint.officeapps.live.com 
 # ICAP server url
-ICAP_URL=icap://127.0.0.1:1344/gw_rebuild
+ICAP_URL=icap://3.139.22.215:1344/gw_rebuild
 # Root domain , the domain appended to the original website domain
 ROOT_DOMAIN=glasswall-icap.com
 SQUID_IP=127.0.0.1


### PR DESCRIPTION
1- Updated Readme with installation steps
2- fixed some spacing issues in allowed domains which errors squid docker
3- added ICAP loadbalancer URL as a default setting